### PR TITLE
Add support for OS X

### DIFF
--- a/source/dred/dred.h
+++ b/source/dred/dred.h
@@ -11,6 +11,12 @@
 #endif
 #endif
 
+// File I/O is 64-bit by default on macOS
+#ifdef __APPLE__
+#define off64_t off_t
+#define fopen64 fopen
+#endif
+
 
 // Standard headers.
 #include <stdlib.h>
@@ -21,8 +27,7 @@
 // Platform headers.
 #ifdef _WIN32
 #include <windows.h>
-#endif
-#ifdef __linux__
+#else
 #include <sys/file.h>
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>

--- a/source/dred/dred_build_config.h
+++ b/source/dred/dred_build_config.h
@@ -12,8 +12,8 @@
 #define DRED_WIN32
 #define DRED_EXE_NAME               "dred.exe"
 #endif
-#ifdef __linux__
-#define DRED_LINUX
+#if defined(__unix__) || defined(__linux__) || defined(__APPLE__)
+#define DRED_UNIX
 #define DRED_GTK
 #define DRED_EXE_NAME               "dred"
 #endif

--- a/source/dred/dred_context.c
+++ b/source/dred/dred_context.c
@@ -2511,9 +2511,7 @@ dred_font* dred__load_system_font_ui(dred_context* pDred)
     fontDesc.size = 12;
     fontDesc.weight = dred_gui_font_weight_normal;
     fontDesc.slant = dred_gui_font_slant_none;
-#endif
-
-#ifdef __linux__
+#else
     strcpy_s(fontDesc.family, sizeof(fontDesc.family), "sans");
     fontDesc.size = 13;
     fontDesc.weight = dred_gui_font_weight_normal;

--- a/source/dred/dred_package_library.c
+++ b/source/dred/dred_package_library.c
@@ -66,9 +66,8 @@ dr_bool32 dred_construct_library_path(char* pathOut, size_t pathOutSize, const c
     const char* platformSubPath = "bin/"
 #ifdef DRED_WIN32
         "win32";
-#endif
-#ifdef DRED_LINUX
-        "linux";
+#else
+        "unix";
 #endif
 
     const char* libraryExt = "_"
@@ -80,9 +79,10 @@ dr_bool32 dred_construct_library_path(char* pathOut, size_t pathOutSize, const c
 #endif
 #ifdef DRED_WIN32
         "dll";
-#endif
-#ifdef DRED_LINUX
+#elif __linux__
         "so";
+#elif __APPLE__
+        "dylib";
 #endif
 
     // Doubtful this will show up in profiling, but this can definitely be optimized.

--- a/source/dred/dred_platform_layer.h
+++ b/source/dred/dred_platform_layer.h
@@ -148,9 +148,7 @@ struct dred_window
     // The high-surrogate from a WM_CHAR message. This is used in order to build a surrogate pair from a couple of WM_CHAR messages. When
     // a WM_CHAR message is received when code point is not a high surrogate, this is set to 0.
     unsigned short utf16HighSurrogate;
-#endif
-
-#ifdef __linux__
+#else
     // The GTK window.
     GtkWidget* pGTKWindow;
     GtkWidget* pGTKBox;

--- a/source/external/dr.h
+++ b/source/external/dr.h
@@ -3198,6 +3198,25 @@ dr_bool32 dr_release_semaphore(dr_semaphore semaphore)
 /////////////////////////////////////////////////////////
 // Timing
 
+// macOS does not have clock_gettime so define it separately
+#ifdef __MACH__
+#include <mach/mach_time.h>
+#define CLOCK_REALTIME 0
+#define CLOCK_MONOTONIC 0
+int clock_gettime(int clk_id, struct timespec* t)
+{
+    mach_timebase_info_data_t timebase;
+    mach_timebase_info(&timebase);
+    uint64_t time;
+    time = mach_absolute_time();
+    double nseconds = ((double)time * (double)timebase.numer) / ((double)timebase.denom);
+    double seconds = ((double)time * (double)timebase.numer) / ((double)timebase.denom * 1e9);
+    t->tv_sec = seconds;
+    t->tv_nsec = nseconds;
+    return 0;
+}
+#endif
+
 #ifdef _WIN32
 static LARGE_INTEGER g_DRTimerFrequency = {{0}};
 void dr_timer_init(dr_timer* pTimer)


### PR DESCRIPTION
This makes the build work on OS X. However, the linking is currently failing:
```
Undefined symbols for architecture x86_64:
  "_gtk_clipboard_get_default", referenced from:
      _dred_clipboard_set_text__gtk in dred_main-9a5602.o
      _dred_clipboard_get_text__gtk in dred_main-9a5602.o
ld: symbol(s) not found for architecture x86_64
```
Oddly enough, `gtk_clipboard_get_default` is defined in GTK's `clipboard.h` header, but `nm -gU` doesn't show it in `libgtk`.

Thus **this is a WIP** until I can figure that part out. I just figured I'd open the PR now in case anyone has insight/suggestions/sagely advice/whatever.

Also, a note for those looking to build on OS X using this branch: the command is the same as that specified for Linux, except `-lrt` should be omitted.

Fixes #1