### PR TITLE
DTK: Compilation error in dtk_io.c fix

### DIFF
--- a/source/dred/dtk/dtk_io.c
+++ b/source/dred/dtk/dtk_io.c
@@ -91,7 +91,7 @@ dtk_bool32 dtk_file_exists__posix(const char* filePath)
 char* dtk_get_current_directory__posix()
 {
     char* pDirTemp = getcwd(NULL, 0);
-    if (pDir == NULL) {
+    if (pDirTemp == NULL) {
         return NULL;
     }
 


### PR DESCRIPTION
Small typo in dtk_io.c that was supposed to be pDirTemp but instead was pDir.